### PR TITLE
refactor:Fix env

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -21,11 +21,11 @@ jobs:
       - name: Download Flutter packages
         run: flutter pub get
 
-      - name: Create env
+      - name: Create .env
         run: |
-          touch env
-          echo $LIFFID >> env
-          echo $GAS_URL >> env
+          touch .env
+          echo $LIFFID >> .env
+          echo $GAS_URL >> .env
 
       - run: flutter build web
       - uses: FirebaseExtended/action-hosting-deploy@v0

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -16,10 +16,10 @@ jobs:
       - name: Download Flutter packages
         run: flutter pub get
 
-      - name: Create env
+      - name: Create .env
         run: |
-          touch env
-          echo ${{secrets.ENV}} >> env
+          touch .env
+          echo ${{secrets.ENV}} >> .env
 
       - run: flutter build web
       - uses: FirebaseExtended/action-hosting-deploy@v0

--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,7 @@ migrate_working_dir/
 .pub-cache/
 .pub/
 /build/
-env
+.env
 
 # Symbolication related
 app.*.symbols

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,7 +9,7 @@ import 'schedules_page.dart';
 String groupId = '';
 
 Future<void> main() async {
-  await dotenv.load(fileName: 'env');
+  await dotenv.load(fileName: '.env');
   // TODO: flutter_line_liff パッケージの使用の廃止を検討する。
   final id = dotenv.get('LIFFID', fallback: 'LIFFID not found');
   await FlutterLineLiff().init(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,4 +23,4 @@ dev_dependencies:
 flutter:
   uses-material-design: true
   assets:
-    - env
+    - .env


### PR DESCRIPTION
# 関連のタスクissue<span style="color: red; ">*</span>
<!-- #をつけてissue番号を記載-->
close #39 

# 対応したこと<span style="color: red; ">*</span>
- 以下の荒田さんのSlack内容の対応
(firebase.jsonについては既に変更されたものがコミットされておりましたので未修正)
> slack 9/29 16:29
dotenvで".env"が使用できないない理由が分かりました。
firebase deploy(改行)
したときのdeploy動作をコントロールするために参照するfirebase.json内に、ignore"項目として"/.*" というものがあり、先頭にドットが付くファイルはデプロイ対象から外されていました。つまり、既定では".env"はデプロイされないのです。
先のignore項目を"/.* !**/.env"として、".env"を対象外と設定することで問題を解消することができました。

# 未解決の課題
- なし

# その他・備考

- お手数ですが、ローカル環境のenvファイルを.envへリネームお願いいたします。

## リリース時の注意点
- なし