### PR TITLE
通知メッセージの GAS の実装・LIFF のユーザー ID を用いる実装

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,5 +18,6 @@
     "editor.formatOnPaste": true,
     "editor.formatOnSave": true,
     "editor.formatOnType": true
-  }
+  },
+  "cSpell.words": ["datetime"]
 }

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # flutter_liff_scheduler
 
-Flutter webとliffを組み合わせてスケジュール共有アプリを作るサンプルプロジェクト。
+Flutter Web と LIFF を組み合わせてスケジュール共有アプリを作るサンプルプロジェクト。
 
 ![architecture.drawio.png](./docs/architecture.drawio.png)
 
 ## 開発環境
 
-```
+```bash
 % fvm flutter --version
 Flutter 3.3.1 • channel stable • https://github.com/flutter/flutter.git
 Framework • revision 4f9d92fbbd (2 weeks ago) • 2022-09-06 17:54:53 -0700
@@ -16,35 +16,42 @@ Tools • Dart 2.18.0 • DevTools 2.15.0
 
 ## ローカル環境での実行方法
 
-- fvmでflutterのバージョンをあわせる
+[FVM](https://fvm.app/docs/getting_started/in) の導入
+
+```bash
+brew tap leoafarias/fvm
+brew install fvm
+```
+
+FVM で所定のバージョンの Flutter SDK の環境を構築
 
 ```bash
 fvm install
-
-# fvmが未インストールなら先に以下を実行
-pub global activate fvm
-export PATH="$PATH":"$HOME/.pub-cache/bin"
 ```
 
-- デバッグ実行
+デバッグ実行
 
 ```bash
 flutter run -d web-server --web-port 8080
 ```
 
-- ngrokでの一時公開(flutter runしているターミナルとは別ターミナルで実施)
+ngrok のインストール
+
+```bash
+brew install ngrok
+```
+
+<https://dashboard.ngrok.com/> にアクセスしサインアップした後に、認証を行う。
+
+```bash
+ngrok config add-authtoken <your-auth-token>
+```
+
+ngrok での一時公開（flutter runしているターミナルとは別ターミナルで実行する）
 
 ```bash
 ngrok http 8080
-
-# ngrokをインストールしていない場合は以下を実施
-## ngrokをインストール
-brew install ngrok
-## 以下のURLにアクセスしSignUp後 Your AuthtokenからTokenをコピー
-https://dashboard.ngrok.com/
-## 控えたTokenを入れて認証
-ngrok config add-authtoken <Your Authtoken>
 ```
 
-- ngrokを起動したターミナルで表示されている`Forwarding`の`https://<ランダム値>.ngrok.io`のURLをLINE Developersコンソールから対象のLiffが紐付いているLINEログインチャネルのコールバックURLに指定する。
-- 上記の設定でngrokが払い出したURL経由でLINEログインが許可される様になる。
+- ngrokを起動したターミナルで表示されている `Forwarding` の `https://<ランダム値>.ngrok.io` のURLを LINE Developers コンソールから対象の LIFF が紐付いている LINE ログインチャネルのコールバックURLに指定する。
+- 上記の設定で ngrok が払い出した URL 経由で LINEログイン が許可される様になる。

--- a/gas/README.md
+++ b/gas/README.md
@@ -64,3 +64,15 @@ clasp pull
 Web 画面の「Deploy > New deployment」から Web app を選択してデプロイする。
 
 2 回目以降は「Deploy > Manage deployments」から New version を反映すれば良い。
+
+## その他の設定
+
+GAS に紐づくスプレッドシートの列名とその順番はこのスプレッドシートと一致させる必要がある。
+
+<https://docs.google.com/spreadsheets/d/1n_Dem-FpKK36tJ-G5VYilWDuN0VBoDaRkvR6B2ziC7M/edit#gid=0>
+
+また、GAS の Script Properties に `CHANNEL_ACCESS_TOKEN` の名前で、対応する LINE ログインチャネルの CHANNEL_ACCESS_TOKEN を設定する。
+
+```txt
+CHANNEL_ACCESS_TOKEN=<自分の CHANNEL_ACCESS_TOKEN> 
+```

--- a/gas/main.js
+++ b/gas/main.js
@@ -1,31 +1,157 @@
 /** スケジュール一覧を保存するシート名。 */
-const schedulesSheetName = 'schedules'
+const SCHEDULES_SHEET_NAME = 'schedules'
 
-/** ヘッダ行を除く最初の有効なデータセル */
-const firstCell = {
-  row: 2,
-  column: 1,
+/** スプレッドシートのスキーマ。 */
+const SCHEMA = {
+  userId: {
+    columnName: 'userId',
+    columnNumber: 0,
+  },
+  title: {
+    columnName: 'title',
+    columnNumber: 1,
+  },
+  dueDateTime: {
+    columnName: 'dueDateTime',
+    columnNumber: 2,
+  },
+  isNotified: {
+    columnName: 'isNotified',
+    columnNumber: 3,
+  },
+}
+
+/** ヘッダ行を除く最初の有効なデータセル。 */
+const firstCell = { row: 2, column: 1 }
+
+/** スケジュール一覧が記録されているシート。 */
+function getSchedulesSheet() {
+  return SpreadsheetApp.getActiveSpreadsheet().getSheetByName(
+    SCHEDULES_SHEET_NAME
+  )
 }
 
 /**
- * GET API
- */
-function doGet(e) {
-  const sheet =
-    SpreadsheetApp.getActiveSpreadsheet().getSheetByName(schedulesSheetName)
+ * 毎時実行して、次の 1 時間の間のスケジュールを LINE Messaging API でお知らせする。
+ *
+ * 例：
+ * この関数が、2022-11-01 09:20:00 に発火した場合、
+ * dueDateTime が 2022-11-01 10:00:00 〜 2022-11-01 10:59:59 の間である
+ * スケジュールを含むメッセージが送信される。
+ * */
+function notifySchedules() {
+  const notificationTargetSchedules = fetchNotificationTargetSchedules()
+  if (notificationTargetSchedules.length === 0) {
+    console.log('近づいているスケジュールはありません。')
+    return
+  }
+
+  const messagesByUserId = {}
+  for (const row of notificationTargetSchedules) {
+    const userId = row[SCHEMA.userId.columnNumber]
+    const message = `${row[SCHEMA.title.columnNumber]} (${row[
+      SCHEMA.dueDateTime.columnNumber
+    ].toLocaleString('ja-JP')})`
+    if (userId in messagesByUserId) {
+      messagesByUserId[userId].push(message)
+    } else {
+      messagesByUserId[userId] = [message]
+    }
+  }
+
+  for (const userId in messagesByUserId) {
+    console.log(`userId: ${userId}, messages: ${messagesByUserId[userId]}`)
+    pushMessageToUser(userId, messagesByUserId[userId])
+  }
+}
+
+/** スプレッドシートからスケジュールを全件取得して、dueDateTime の降順にして返す。 */
+function fetchAllSchedulesFromSpreadSheet() {
+  sheet = getSchedulesSheet()
   const range = sheet.getRange(
     firstCell.row,
     firstCell.column,
     sheet.getLastRow() - (firstCell.row - 1), // ヘッダ行を除くため
     sheet.getLastColumn()
   )
-  const body = range.getValues().map((row) => {
+  return range
+    .getValues()
+    .sort((a, b) =>
+      a[SCHEMA.dueDateTime.columnNumber] > b[SCHEMA.dueDateTime.columnNumber]
+        ? -1
+        : 1
+    )
+}
+
+/** スケジュール一覧から指定したユーザー ID のものだけをフィルタして返す。 */
+function fetchSchedulesByUserId(userId) {
+  const schedules = fetchAllSchedulesFromSpreadSheet()
+  return schedules.filter((row) => row[SCHEMA.userId.columnNumber] === userId)
+}
+
+/** スケジュール一覧から通知のターゲットとなるものだけをフィルタして返す。 */
+function fetchNotificationTargetSchedules() {
+  const now = new Date()
+  const schedules = fetchAllSchedulesFromSpreadSheet()
+  const minDueDateTime = new Date(
+    now.getFullYear(),
+    now.getMonth(),
+    now.getDate(),
+    now.getHours() + 1
+  )
+  const maxDueDateTime = new Date(
+    now.getFullYear(),
+    now.getMonth(),
+    now.getDate(),
+    now.getHours() + 2
+  )
+  return schedules.filter(
+    (row) =>
+      row[SCHEMA.dueDateTime.columnNumber] >= minDueDateTime &&
+      row[SCHEMA.dueDateTime.columnNumber] < maxDueDateTime &&
+      !row[SCHEMA.isNotified.columnNumber]
+  )
+}
+
+/** 指定した ID のユーザーに、LINE の Messaging API でメッセージを送信する。 */
+function pushMessageToUser(userId, messageTexts) {
+  UrlFetchApp.fetch('https://api.line.me/v2/bot/message/push', {
+    headers: {
+      'Content-Type': 'application/json; charset=UTF-8',
+      Authorization: `Bearer ${PropertiesService.getScriptProperties().getProperty(
+        'CHANNEL_ACCESS_TOKEN'
+      )}`,
+    },
+    method: 'post',
+    payload: JSON.stringify({
+      to: userId,
+      messages: [
+        { type: 'text', text: '近づいているスケジュールのお知らせ' },
+        ...messageTexts.map((text) => {
+          return { type: 'text', text }
+        }),
+      ],
+    }),
+  })
+}
+
+/**
+ * GET API。
+ * スケジュール一覧を取得する。
+ */
+function doGet(e) {
+  const userId = e.parameter.userId
+  if (userId === undefined) {
+    console.error('userId が指定されていません。')
+    throw 'userId を指定してください。'
+  }
+  const schedules = fetchSchedulesByUserId(userId)
+  const body = schedules.map((row) => {
     return {
-      scheduleId: row[0],
-      title: row[1],
-      createdAt: row[2],
-      dueDateTime: row[3],
-      isNotified: row[4],
+      userId: row[SCHEMA.userId.columnNumber],
+      title: row[SCHEMA.title.columnNumber],
+      dueDateTime: row[SCHEMA.dueDateTime.columnNumber],
+      isNotified: row[SCHEMA.isNotified.columnNumber],
     }
   })
   const response = ContentService.createTextOutput(JSON.stringify(body))
@@ -34,32 +160,18 @@ function doGet(e) {
 }
 
 /**
- * POST API
+ * POST API。
+ * スケジュールを登録する。
  */
 function doPost(e) {
-  // NOTE: type の判定は未対応。
+  const userId = e.parameter.userId
   const title = e.parameter.title
   const dueDateTime = new Date(e.parameter.dueDateTime)
+  const values = { userId, title, dueDateTime, isNotified: false }
 
-  const record = {
-    // schedule を識別するのにフィールドに UUID をもたせるのはちょっと冗長か...？
-    // 行番号でも十分か...？
-    scheduleId: getUuid(),
-    title,
-    dueDateTime,
-    createdAt: new Date(),
-    isNotified: false,
-  }
-
-  const sheet =
-    SpreadsheetApp.getActiveSpreadsheet().getSheetByName(schedulesSheetName)
-  sheet.appendRow(Object.values(record))
-  const response = ContentService.createTextOutput(JSON.stringify(record))
+  sheet = getSchedulesSheet()
+  sheet.appendRow(Object.values(values))
+  const response = ContentService.createTextOutput(JSON.stringify(values))
   response.setMimeType(ContentService.MimeType.JSON)
   return response
-}
-
-/** UUID を生成する。 */
-function getUuid() {
-  return Utilities.getUuid()
 }

--- a/gas/main.js
+++ b/gas/main.js
@@ -197,11 +197,12 @@ function doGet(e) {
  * スケジュールを登録する。
  */
 function doPost(e) {
-  const rowNumber = '= ROW() - 1'
+  const rowNumber = '= ROW()'
   const userId = e.parameter.userId
   const title = e.parameter.title
   const dueDateTime = new Date(e.parameter.dueDateTime)
-  const values = { rowNumber, userId, title, dueDateTime, isNotified: false }
+  const isNotified = false
+  const values = { rowNumber, userId, title, dueDateTime, isNotified }
 
   sheet = getSchedulesSheet()
   sheet.appendRow(Object.values(values))

--- a/gas/main.js
+++ b/gas/main.js
@@ -150,7 +150,7 @@ function doGet(e) {
     return {
       userId: row[SCHEMA.userId.columnNumber],
       title: row[SCHEMA.title.columnNumber],
-      dueDateTime: row[SCHEMA.dueDateTime.columnNumber],
+      dueDateTime: row[SCHEMA.dueDateTime.columnNumber].getTime(),
       isNotified: row[SCHEMA.isNotified.columnNumber],
     }
   })

--- a/lib/js/flutter_liff.dart
+++ b/lib/js/flutter_liff.dart
@@ -7,7 +7,7 @@ import 'package:js/js.dart';
 external Object init(Config config);
 
 @JS('getUserId')
-external Object getUserId();
+external Object getUserId([bool ignoreError = false]);
 
 @JS('getLiffId')
 external String getLiffId();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
@@ -26,8 +27,8 @@ Future<void> main() async {
     ),
   );
 
-  // ユーザー ID を取得して上書きする。
-  userId = await promiseToFuture(liff.getUserId()) ?? '';
+  // デバッグモードではユーザー ID 取得のエラーを無視する。
+  userId = await promiseToFuture(liff.getUserId(kDebugMode));
   runApp(const App());
 }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,8 +8,8 @@ import 'js/flutter_liff.dart' as liff;
 import 'js/main_js.dart';
 import 'schedules_page.dart';
 
-/// TODO: groupId をグローバルに書くのをやめることを検討する。
-String groupId = '';
+/// TODO: userId をグローバルに書くのをやめることを検討する。
+String userId = '';
 
 Future<void> main() async {
   await dotenv.load(fileName: '.env');
@@ -26,7 +26,7 @@ Future<void> main() async {
       ),
     ),
   );
-  groupId = await promiseToFuture(liff.getGroupId()) ?? '';
+  userId = await promiseToFuture(liff.getUserId()) ?? '';
   runApp(const App());
 }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,28 +8,31 @@ import 'js/flutter_liff.dart' as liff;
 import 'js/main_js.dart';
 import 'schedules_page.dart';
 
-/// TODO: userId をグローバルに書くのをやめることを検討する。
+/// LIFF アプリとして起動すると、main() の中で 上書きされるユーザー ID。
 String userId = '';
 
 Future<void> main() async {
   await dotenv.load(fileName: '.env');
-  final id = dotenv.get('LIFFID', fallback: 'LIFFID not found');
-
-  // PromiseをFutureに変換する為、promiseToFuture()でラップ
+  final liffId = dotenv.get('LIFFID', fallback: '.env に LIFFID を指定してください。');
+  // JS の Promise を Dart の Future に変換するために promiseToFuture() でラップする。
   await promiseToFuture(
     liff.init(
       liff.Config(
-        liffId: id,
-        // js側に関数を渡す為、allowInterop()でラップ
-        successCallback: allowInterop(() => log('liff init success!!!')),
-        errorCallback: allowInterop((e) => log('liff init failed with $e')),
+        liffId: liffId,
+        // JS に関数を渡すために allowInterop() でラップする。
+        successCallback: allowInterop(() => log('LIFF の初期化に成功しました。')),
+        errorCallback: allowInterop((e) => log('LIFF の初期化に失敗しました。$e')),
       ),
     ),
   );
+
+  // ユーザー ID を取得して上書きする。
   userId = await promiseToFuture(liff.getUserId()) ?? '';
   runApp(const App());
 }
 
+/// main() の runApp() の引数に指定するウィジェット。
+/// 中で MaterialApp を返す。
 class App extends StatelessWidget {
   const App({super.key});
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,7 +6,7 @@ import 'package:js/js_util.dart';
 
 import 'js/flutter_liff.dart' as liff;
 import 'js/main_js.dart';
-import 'schedules_page.dart';
+import 'ui/schedule.dart';
 
 /// LIFF アプリとして起動すると、main() の中で 上書きされるユーザー ID。
 String userId = '';

--- a/lib/schedule.dart
+++ b/lib/schedule.dart
@@ -22,7 +22,7 @@ class Schedule {
   factory Schedule.fromJson(Map<String, dynamic> json) => Schedule(
         userId: (json['userId'] ?? '') as String,
         title: (json['title'] ?? '') as String,
-        dueDateTime: DateTime.parse(json['dueDateTime']),
+        dueDateTime: DateTime.fromMillisecondsSinceEpoch(json['dueDateTime']),
         isNotified: json['isNotified'] ?? false,
       );
 }

--- a/lib/schedule.dart
+++ b/lib/schedule.dart
@@ -1,24 +1,28 @@
 /// アプリで管理・操作するスケジュール。
 class Schedule {
   Schedule({
-    required this.scheduleId,
+    required this.userId,
     required this.title,
     required this.dueDateTime,
     this.isNotified = false,
-    this.createdAt,
   });
 
-  final String scheduleId;
+  /// LIFF のユーザー ID。
+  final String userId;
+
+  /// スケジュールのタイトル。
   final String title;
+
+  /// スケジュールの締め切り日時。
   final DateTime dueDateTime;
+
+  /// スケジュールを LINE Messaging API で通知済みかどうか。
   final bool isNotified;
-  final DateTime? createdAt;
 
   factory Schedule.fromJson(Map<String, dynamic> json) => Schedule(
-        scheduleId: (json['scheduleId'] ?? '') as String,
+        userId: (json['userId'] ?? '') as String,
         title: (json['title'] ?? '') as String,
         dueDateTime: DateTime.parse(json['dueDateTime']),
         isNotified: json['isNotified'] ?? false,
-        createdAt: DateTime.tryParse(json['createdAt']),
       );
 }

--- a/lib/schedules_page.dart
+++ b/lib/schedules_page.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_datetime_picker/flutter_datetime_picker.dart';
 
 import 'http_request.dart';
-import 'main.dart';
 import 'schedule.dart';
 
 /// スケジュール一覧ページ。
@@ -33,7 +32,6 @@ class SchedulesPageState extends State<SchedulesPage> {
               },
               child: Column(
                 children: [
-                  Text(userId),
                   Expanded(
                     child: ListView.builder(
                       itemCount: schedules.length,

--- a/lib/schedules_page.dart
+++ b/lib/schedules_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_datetime_picker/flutter_datetime_picker.dart';
 
 import 'http_request.dart';
+import 'main.dart';
 import 'schedule.dart';
 
 /// スケジュール一覧ページ。
@@ -30,19 +31,26 @@ class SchedulesPageState extends State<SchedulesPage> {
                 await _schedules;
                 setState(() {});
               },
-              child: ListView.builder(
-                itemCount: schedules.length,
-                itemBuilder: (context, index) {
-                  final schedule = schedules[index];
-                  return ListTile(
-                    leading: Icon(
-                      schedule.isNotified
-                          ? Icons.check_box_outlined
-                          : Icons.check_box_outline_blank,
+              child: Column(
+                children: [
+                  Text(userId),
+                  Expanded(
+                    child: ListView.builder(
+                      itemCount: schedules.length,
+                      itemBuilder: (context, index) {
+                        final schedule = schedules[index];
+                        return ListTile(
+                          leading: Icon(
+                            schedule.isNotified
+                                ? Icons.check_box_outlined
+                                : Icons.check_box_outline_blank,
+                          ),
+                          title: Text(schedule.title),
+                        );
+                      },
                     ),
-                    title: Text(schedule.title),
-                  );
-                },
+                  ),
+                ],
               ),
             );
           }

--- a/lib/ui/schedule.dart
+++ b/lib/ui/schedule.dart
@@ -155,6 +155,7 @@ class CreateSchedulePageState extends State<CreateSchedulePage> {
                   readOnly: true,
                   onTap: () => DatePicker.showDateTimePicker(
                     context,
+                    currentTime: dueDateTime ?? DateTime.now(),
                     minTime: DateTime.now(),
                     onConfirm: (dateTime) => setState(() {
                       dueDateTime = dateTime;

--- a/lib/ui/schedule.dart
+++ b/lib/ui/schedule.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_datetime_picker/flutter_datetime_picker.dart';
 import 'package:flutter_liff_scheduler/main.dart';
+import 'package:flutter_liff_scheduler/utils/date_time.dart';
 
 import '../http_request.dart';
 import '../schedule.dart';
@@ -52,12 +53,26 @@ class SchedulesPageState extends State<SchedulesPage> {
                       itemBuilder: (context, index) {
                         final schedule = schedules[index];
                         return ListTile(
-                          leading: Icon(
-                            schedule.isNotified
-                                ? Icons.check_box_outlined
-                                : Icons.check_box_outline_blank,
+                          leading: Container(
+                            margin: const EdgeInsets.only(top: 4),
+                            padding: const EdgeInsets.all(4),
+                            decoration: BoxDecoration(
+                              color: schedule.isNotified ? Colors.grey : Colors.blue,
+                              borderRadius: BorderRadius.circular(4),
+                            ),
+                            child: Text(
+                              schedule.isNotified ? '通知済み' : '通知予定',
+                              style: const TextStyle(
+                                color: Colors.white,
+                                fontSize: 10,
+                              ),
+                            ),
                           ),
-                          title: Text(schedule.title),
+                          title: Text(
+                            schedule.title,
+                            style: const TextStyle(fontWeight: FontWeight.bold),
+                          ),
+                          subtitle: Text(schedule.dueDateTime.toJapaneseFormat),
                         );
                       },
                     ),
@@ -143,7 +158,7 @@ class CreateSchedulePageState extends State<CreateSchedulePage> {
                     minTime: DateTime.now(),
                     onConfirm: (dateTime) => setState(() {
                       dueDateTime = dateTime;
-                      dueDateTimeController.text = dateTime.toIso8601String();
+                      dueDateTimeController.text = dateTime.toJapaneseFormat;
                     }),
                   ),
                   decoration: const InputDecoration(

--- a/lib/ui/schedule.dart
+++ b/lib/ui/schedule.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_datetime_picker/flutter_datetime_picker.dart';
+import 'package:flutter_liff_scheduler/main.dart';
 
 import '../http_request.dart';
 import '../schedule.dart';
@@ -32,6 +33,19 @@ class SchedulesPageState extends State<SchedulesPage> {
               },
               child: Column(
                 children: [
+                  if (userId.isEmpty)
+                    Container(
+                      margin: const EdgeInsets.all(16),
+                      padding: const EdgeInsets.all(8),
+                      decoration: BoxDecoration(
+                        color: Colors.yellow[100],
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                      child: const Text(
+                        '⚠️ ユーザー ID を取得できていないため '
+                        'LIFF アプリとして正常に機能しない可能性があります',
+                      ),
+                    ),
                   Expanded(
                     child: ListView.builder(
                       itemCount: schedules.length,

--- a/lib/ui/schedule.dart
+++ b/lib/ui/schedule.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_datetime_picker/flutter_datetime_picker.dart';
 
-import 'http_request.dart';
-import 'schedule.dart';
+import '../http_request.dart';
+import '../schedule.dart';
 
 /// スケジュール一覧ページ。
 class SchedulesPage extends StatefulWidget {

--- a/lib/ui/schedule.dart
+++ b/lib/ui/schedule.dart
@@ -153,15 +153,24 @@ class CreateSchedulePageState extends State<CreateSchedulePage> {
                 TextField(
                   controller: dueDateTimeController,
                   readOnly: true,
-                  onTap: () => DatePicker.showDateTimePicker(
-                    context,
-                    currentTime: dueDateTime ?? DateTime.now(),
-                    minTime: DateTime.now(),
-                    onConfirm: (dateTime) => setState(() {
-                      dueDateTime = dateTime;
-                      dueDateTimeController.text = dateTime.toJapaneseFormat;
-                    }),
-                  ),
+                  onTap: () async {
+                    final now = DateTime.now();
+                    final oneHourLater = DateTime(
+                      now.year,
+                      now.month,
+                      now.day,
+                      now.hour + 1,
+                    );
+                    await DatePicker.showDateTimePicker(
+                      context,
+                      currentTime: dueDateTime ?? oneHourLater,
+                      minTime: oneHourLater,
+                      onConfirm: (dateTime) => setState(() {
+                        dueDateTime = dateTime;
+                        dueDateTimeController.text = dateTime.toJapaneseFormat;
+                      }),
+                    );
+                  },
                   decoration: const InputDecoration(
                     labelText: '日時',
                     border: OutlineInputBorder(),

--- a/lib/utils/date_time.dart
+++ b/lib/utils/date_time.dart
@@ -1,0 +1,23 @@
+import 'package:intl/intl.dart';
+
+extension DateTimeExtension on DateTime {
+  /// 日本の曜日
+  static const List<String> japaneseWeekdays = [
+    '月',
+    '火',
+    '水',
+    '木',
+    '金',
+    '土',
+    '日',
+  ];
+
+  /// 「2022年01月01日 13時00分」のような文字列に変換する
+  String get toJapaneseFormat => DateFormat('yyyy年MM月dd日 HH時mm分').format(this);
+
+  /// 入力日の日本の曜日を返す
+  String get japaneseWeekDay => japaneseWeekdays[_weekDayInt(this) - 1];
+
+  /// 入力日の曜日を整数型で返す
+  int _weekDayInt(DateTime dateTime) => dateTime.weekday;
+}

--- a/lib/utils/date_time.dart
+++ b/lib/utils/date_time.dart
@@ -1,23 +1,6 @@
 import 'package:intl/intl.dart';
 
 extension DateTimeExtension on DateTime {
-  /// 日本の曜日
-  static const List<String> japaneseWeekdays = [
-    '月',
-    '火',
-    '水',
-    '木',
-    '金',
-    '土',
-    '日',
-  ];
-
   /// 「2022年01月01日 13時00分」のような文字列に変換する
   String get toJapaneseFormat => DateFormat('yyyy年MM月dd日 HH時mm分').format(this);
-
-  /// 入力日の日本の曜日を返す
-  String get japaneseWeekDay => japaneseWeekdays[_weekDayInt(this) - 1];
-
-  /// 入力日の曜日を整数型で返す
-  int _weekDayInt(DateTime dateTime) => dateTime.weekday;
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -95,6 +95,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "4.0.1"
+  intl:
+    dependency: "direct main"
+    description:
+      name: intl
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.17.0"
   js:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   flutter_datetime_picker: ^1.5.1
   flutter_dotenv: ^5.0.1
   http: ^0.13.5
+  intl: ^0.17.0
   js: ^0.6.4
 
 dev_dependencies:

--- a/web/flutter_liff.js
+++ b/web/flutter_liff.js
@@ -1,34 +1,53 @@
-async function init(config){
-    console.log("init called")
-    await liff.init({
-        liffId: config["liffId"],
-        withLoginOnEternalBrowser: true,
+async function init(config) {
+  console.log('init called')
+  await liff
+    .init({
+      liffId: config['liffId'],
+      withLoginOnEternalBrowser: true,
     })
     .then(() => {
-        config["successCallback"]()
-     })
-     .catch((err) => {
-        config["errorCallback"](err)
-     });
+      config['successCallback']()
+    })
+    .catch((err) => {
+      config['errorCallback'](err)
+    })
 }
 
-function getLiffId(){
-    return liff.id
+function getLiffId() {
+  return liff.id
 }
 
-async function getUserId(){
-    console.log("getUserId called")
-   const profile = await liff.getProfile()
-   return profile["userId"]
+/**
+ * @param {boolean} ignoreError エラーを無視して、空文字を返す。
+ * LIFF アプリとしてではなく、単なる Flutter Web アプリとしてデバッグするような
+ * 用途を想定し、ignoreError = true を指定すると、エラーを握りつぶして、空文字を返す。
+ *
+ * @return {string} LIFF アプリとして起動している際に得られる userId を返す。
+ */
+async function getUserId(ignoreError = false) {
+  if (ignoreError) {
+    try {
+      console.log('getUserId called')
+      const profile = await liff.getProfile()
+      return profile['userId']
+    } catch (e) {
+      console.error('ユーザー ID が取得できませんでした。')
+      return ''
+    }
+  } else {
+    console.log('getUserId called')
+    const profile = await liff.getProfile()
+    return profile['userId']
+  }
 }
 
-async function getGroupId(){
-    console.log("getGroupId called")
-   const context = await liff.getContext()
-   return context["groupId"]
+async function getGroupId() {
+  console.log('getGroupId called')
+  const context = await liff.getContext()
+  return context['groupId']
 }
 
-async function getAccessToken(){
-    console.log("getAccessToken called")
-    return await liff.getAccessToken()
+async function getAccessToken() {
+  console.log('getAccessToken called')
+  return await liff.getAccessToken()
 }


### PR DESCRIPTION
# 関連のタスクissue<span style="color: red; ">*</span>

<!-- #をつけてissue番号を記載-->
close #17 #16 #7 #3 

# 対応したこと<span style="color: red; ">*</span>

- GAS による LINE messaging API での通知メッセージ機能を実装しました
- LIFF の起動周りと、それによって userId を取得する関係のコードをリファクタしました
- スケジュール一覧、スケジュール追加画面の改善・リファクタを行いました
画面収録：

https://flutteruniv.slack.com/archives/C03SH6PJ4AU/p1668517918907409

# 未解決の課題

- あれば書く

# その他・備考

## スプレッドシートの仕様が変わりました

自身のスプレッドシートを用いる場合は、

https://docs.google.com/spreadsheets/d/1n_Dem-FpKK36tJ-G5VYilWDuN0VBoDaRkvR6B2ziC7M/edit#gid=0

に仕様（列名）を揃えてください。

## GAS による通知メッセージの送信の仕様を簡素化しました

GAS の Hourly の定期実行で `notifySchedules()` が走るように設定し、次の 1 時間のスケジュールを通知するようにします。

つまり、たとえば 2022-11-15 09:00 台に実行される `notifySchedules()` 関数では、2022-11-15 10:00 〜 2022-11-15 10:59:59 のスケジュールを通知することにします。

実際にはトリガーの設定はしていませんが、GAS 上で `notifySchedules()` を直接実行することで動作を確認しています。

## リリース時の注意点

- あれば書く